### PR TITLE
UTF-8 encoding/decoding fails with unrepresentable bytes

### DIFF
--- a/weechat_otr.py
+++ b/weechat_otr.py
@@ -1093,14 +1093,14 @@ if weechat.register(
         'smp ask NICK SERVER SECRET [QUESTION] || '
         'smp respond NICK SERVER SECRET || '
         'trust [NICK SERVER] || '
-	'distrust [NICK SERVER] || '
+        'distrust [NICK SERVER] || '
         'policy [POLICY on|off]',
         '',
         'start %(nick) %(irc_servers) %-||'
         'finish %(nick) %(irc_servers) %-||'
         'smp ask|respond %(nick) %(irc_servers) %-||'
         'trust %(nick) %(irc_servers) %-||'
-	'distrust %(nick) %(irc_servers) %-||'
+        'distrust %(nick) %(irc_servers) %-||'
         'policy %(otr_policy) on|off %-||',
         'command_cb',
         '')


### PR DESCRIPTION
as shown here : http://paste.geeknode.org/21d1c2c5

binary values of 0xe9  and similar produce errors as they are latin1 chars, and their code is unrepresentable in utf-8..

This should fix it everywhere and replace those values with a safe '?'.

Let me know if I broke something else somewhere, I did this in a hurry.
