### PR TITLE
change IRC_PRIVMSG_RE to work with minbif

### DIFF
--- a/weechat_otr.py
+++ b/weechat_otr.py
@@ -95,7 +95,7 @@ IRC_PRIVMSG_RE = re.compile(r"""
 \ )?
 PRIVMSG
 \ (?P<to>.+?)
-\ :
+\ :?
 (?P<text>.+)
 """, re.VERBOSE)
 


### PR DESCRIPTION
minbif's private messages don't necessarily have a colon at the start of the text. I changed IRC_PRIVMSG_RE to detect them anyway.

..., so I made the colon optional in IRC_PRIVMSG_RE.
