### PR TITLE
allow channel to start with '&' as per rfc1459/1.3

### DIFF
--- a/weechat_otr.py
+++ b/weechat_otr.py
@@ -204,7 +204,7 @@ def parse_irc_privmsg(message):
     if match:
         result = match.groupdict()
 
-        if result['to'].startswith('#'):
+        if result['to'].startswith(('#','&')):
             result['to_channel'] = result['to']
             result['to_nick'] = None
         else:


### PR DESCRIPTION
this fixes some strange issues with weechat-otr and bitlbee which uses &foo-type channels generously.
