### PR TITLE
Security Fix: split incoming messages at newline characters

### DIFF
--- a/weechat_otr.py
+++ b/weechat_otr.py
@@ -146,8 +146,11 @@ def privmsg(server, nick, message):
         command('', '/quote -server %s PRIVMSG %s :%s' % (server, nick, line))
 
 def build_privmsg_in(fromm, to, msg):
-    """Build an inbound IRC PRIVMSG command."""
-    return ':%s PRIVMSG %s :%s' % (fromm, to, msg)
+    """Build inbound IRC PRIVMSG command(s)."""
+    cmd = []
+    for line in msg.split('\n'):
+        cmd.append(':%s PRIVMSG %s :%s' % (fromm, to, line))
+    return '\n'.join(cmd)
 
 def prnt(buf, message):
     """Wrap weechat.prnt() with utf-8 encode."""


### PR DESCRIPTION
When the encrypted message contains a '\n'-character, weechat-otr does not properly create multiple PRIVMSG commands. Instead, everything but the first line in the message is forwarded to the server verbatim as command, leading to arbitrary irc command execution as the receiver's user.

While not a lot of benign jabber clients seem to send text/plain content inside otr messages, I was able to reproduce the erratic behavior using kopete from kubuntu's 12.04 live-cd.
