### PR TITLE
fix OTR_QUERY_RE

### DIFF
--- a/test/test_weechat_otr.py
+++ b/test/test_weechat_otr.py
@@ -45,6 +45,12 @@ class WeechatOtrTestCase(unittest.TestCase):
         result = weechat_otr.build_privmsg_in('f', 't', 'line1\nline2')
         self.assertEqual(result, ':f PRIVMSG t :line1\n:f PRIVMSG t :line2')
 
+    def test_is_query(self):
+        assembler = weechat_otr.Assembler()
+        assembler.add('ATT: ?OTRv2?someone requested encryption!')
+
+        self.assertTrue(assembler.is_query())
+
     def test_command_cb_start_send_tag_off(self):
         weechat_otr.command_cb(None, None, 'start')
 
@@ -87,4 +93,3 @@ class WeechatOtrTestCase(unittest.TestCase):
 
     def assertNotPrinted(self, buf, text):
         self.assertNotIn(text, sys.modules['weechat'].printed.get(buf, []))
-

--- a/weechat_otr.py
+++ b/weechat_otr.py
@@ -74,7 +74,7 @@ SCRIPT_VERSION = '1.2.0'
 
 OTR_DIR_NAME = 'otr'
 
-OTR_QUERY_RE = re.compile('\?OTR(\?|\??v[a-z\d]*\?)$')
+OTR_QUERY_RE = re.compile('\?OTR(\?|\??v[a-z\d]*\?)')
 
 POLICIES = {
     'allow_v2' : 'allow OTR protocol version 2',
@@ -323,7 +323,7 @@ class Assembler:
 
     def is_query(self):
         """Return true if the buffer is an OTR query."""
-        return OTR_QUERY_RE.match(self.value)
+        return OTR_QUERY_RE.search(self.value)
 
 class IrcContext(potr.context.Context):
     """Context class for OTR over IRC."""


### PR DESCRIPTION
allow the otr query string ("?OTR?...") to appear anywhere within the message as per the spec

see https://github.com/mmb/weechat-otr/issues/38#issuecomment-28905102 for the full explanation
