### PR TITLE
allow smp question and answer to contain non-ascii characters

### DIFF
--- a/weechat_otr.py
+++ b/weechat_otr.py
@@ -783,7 +783,8 @@ def message_in_cb(data, modifier, modifier_data, string):
 
             context.handle_tlvs(tlvs)
         except potr.context.ErrorReceived, e:
-            context.print_buffer('Received OTR error: %s' % e.args[0].error)
+            context.print_buffer('Received OTR error: %s' % (
+                utf8_decode(e.args[0].error)))
         except potr.context.NotEncryptedError:
             context.print_buffer(
                 'Received encrypted data but no private session established.')
@@ -793,7 +794,7 @@ def message_in_cb(data, modifier, modifier_data, string):
             result = utf8_encode(build_privmsg_in(
                 parsed['from'], parsed['to'],
                 'Unencrypted message received: %s' % (
-                    err.args[0])))
+                    utf8_decode(err.args[0]))))
 
     weechat.bar_item_update(SCRIPT_NAME)
 


### PR DESCRIPTION
Having non-ascii characters in SMP question or secret would lead to

```
UnicodeDecodeError: 'ascii' codec can't decode byte 0x?? in position ?: ordinal not in range(128)
```

in several places of the code. This commit should catch all the cases where smp strings are passed to or from weechat/potr.

Note that the encode('raw_unicode_escape') introduced in de6de591 only appears to solve the problem, as the wrong hash is calculated (tested against pidgin/libotr).
