### PR TITLE
fix non-ascii chars in command arguments

### DIFF
--- a/weechat_otr.py
+++ b/weechat_otr.py
@@ -1120,7 +1120,7 @@ def command_cb(data, buf, args):
     result = weechat.WEECHAT_RC_ERROR
 
     try:
-        arg_parts = shlex.split(PYVER.to_unicode(args))
+        arg_parts = [ PYVER.to_unicode(arg) for arg in shlex.split(args) ]
     except:
         debug("Command parsing error.")
         return result


### PR DESCRIPTION
to trigger the error, try "/otr smp respond gemüse"

this reverts part of 95460bdec843b9f63d2577b7093cc06e592f44a6 to avoid a UnicodeEncodeError in shlex:

```
Traceback (most recent call last):
  File "~/.weechat/python/autoload/otr.py", line 1123, in command_cb
    arg_parts = shlex.split(PYVER.to_unicode(args))
  File "/usr/lib/python2.7/shlex.py", line 275, in split
    lex = shlex(s, posix=posix)
  File "/usr/lib/python2.7/shlex.py", line 25, in __init__
    instream = StringIO(instream)
UnicodeEncodeError: 'ascii' codec can't encode character u'\xfc' in position 14: ordinal not in range(128)
```
