### PR TITLE
Handle incoming irc ACTION in unencrypted message

### DIFF
--- a/weechat_otr.py
+++ b/weechat_otr.py
@@ -1035,7 +1035,8 @@ def message_in_cb(data, modifier, modifier_data, string):
             result = string
         except potr.context.UnencryptedMessage as err:
             result = PYVER.to_str(build_privmsgs_in(
-                parsed['from'], parsed['to'], PYVER.to_unicode(err.args[0]),
+                parsed['from'], parsed['to'], PYVER.to_unicode(
+                    msg_plain_from_irc(err.args[0])),
                 'Unencrypted message received: '))
 
     weechat.bar_item_update(SCRIPT_NAME)


### PR DESCRIPTION
This makes sure that if an encrypted message is expected and an ACTION is received, we see

```
Unencrypted message received: /me is bored
```
