### PR TITLE
Wrong message when resetting to default log level

### DIFF
--- a/weechat_otr.py
+++ b/weechat_otr.py
@@ -828,10 +828,8 @@ Note: You can safely omit specifying the peer and server when
 
         if previous_log_level == -1:
             logger_option_name = self.get_logger_option_name(buf)
-            logger_option = weechat.config_get(logger_option_name)
             self.print_buffer(
-                'Restoring buffer logging value to default ({})'.format(
-                    weechat.config_integer_default(logger_option)))
+                'Restoring buffer logging value to default')
             weechat.command(buf, '/mute unset {}'.format(
                 logger_option_name))
 


### PR DESCRIPTION
It seems I may have misunderstood how the default log level works in #72. I recently noticed

```
Restoring buffer logging value to default (0)
```

even though it gets reset to 9. I suggest just removing the `(x)` part. Alternatively, we could use `context.is_logged()` for "on/off" feedback, but that would probably always be "on", otherwise we would not be resetting the log level in the first place.
