### PR TITLE
Use numeric index to check python major version

### DIFF
--- a/weechat_otr.py
+++ b/weechat_otr.py
@@ -108,7 +108,8 @@ class PythonVersion3(object):
         """Convert a Unicode to a utf-8 encoded string."""
         return strng
 
-if sys.version_info.major >= 3:
+# We cannot use version_info.major as this is only supported on python >= 2.7
+if sys.version_info[0] >= 3:
     PYVER = PythonVersion3()
 else:
     PYVER = PythonVersion2()


### PR DESCRIPTION
Python 2.6 and earlier uses a tuple, so indexing by keyword is not supported there.

Fixes the bug reported by `konradb` on IRC.