### PR TITLE
Add support for Python 2.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: python
 sudo: false
 python:
+  - "2.6"
   - "2.7"
   - "3.3"
   - "3.4"
@@ -8,6 +9,7 @@ python:
 install:
   - "pip install pylint"
   - "pip install -r requirements.txt"
+  - "if [ $TRAVIS_PYTHON_VERSION == '2.6' ]; then pip install unittest2; fi"
 script: ./run_tests.sh
 matrix:
   fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ install:
   - "pip install pylint"
   - "pip install -r requirements.txt"
   - "if [ $TRAVIS_PYTHON_VERSION == '2.6' ]; then pip install unittest2; fi"
+  - "sed -i \"s/'ascii', errors='replace'/'ascii', 'replace'/\" $(python -c 'import distutils.sysconfig as s; print(s.get_python_lib())')/potr/proto.py"
 script: ./run_tests.sh
 matrix:
   fast_finish: true

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Testing and security auditing are appreciated.
 
 ## Installation
 
-This script requires Weechat 0.4.2 or later and the
+This script requires Python 2.6 or later and Weechat 0.4.2 or later and the
 [Pure Python OTR](https://github.com/afflux/pure-python-otr)
 package to be installed with one of the following methods:
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Testing and security auditing are appreciated.
 
 This script requires Python 2.6 or later and Weechat 0.4.2 or later and the
 [Pure Python OTR](https://github.com/afflux/pure-python-otr)
-package to be installed with one of the following methods:
+package 1.0.2 or later to be installed with one of the following methods:
 
 Python package:
 ```bash

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -3,4 +3,9 @@
 pylint --rcfile=pylint.rc weechat_otr.py
 pylint --rcfile=pylint.rc weechat_otr_test
 
-python -m unittest discover
+UNITTEST_COMMAND="python -m unittest"
+
+# Python 2.6 compatibility
+python -m unittest -f >/dev/null 2>&1 || UNITTEST_COMMAND="unit2"
+
+$UNITTEST_COMMAND discover

--- a/test_until_fail.sh
+++ b/test_until_fail.sh
@@ -1,7 +1,12 @@
 #!/bin/bash
 
+UNITTEST_COMMAND="unittest"
+
+# Python 2.6 compatibility
+python -m unittest -f >/dev/null 2>&1 || UNITTEST_COMMAND="unit2"
+
 COUNT=0
 
-while python -m unittest discover; do
+while $UNITTEST_COMMAND discover; do
   echo $((COUNT+=1))
 done

--- a/weechat_otr_test/test_command_finish.py
+++ b/weechat_otr_test/test_command_finish.py
@@ -21,23 +21,23 @@ class CommandFinishTestCase(WeechatOtrTestCase):
         weechat_otr.ACCOUNTS['nick@server'] = account
 
     def test_finish_buffer(self):
-        weechat_otr.command_cb(None, 'server_nick2_buffer', 'finish')
+        self.call_command_cb(None, 'server_nick2_buffer', 'finish')
 
         self.assertEqual(self.context.disconnects, 1)
 
     def test_finish_args(self):
-        weechat_otr.command_cb(None, None, 'finish nick2 server')
+        self.call_command_cb(None, None, 'finish nick2 server')
 
         self.assertEqual(self.context.disconnects, 1)
 
     # /otr end is an alias for /otr finish
 
     def test_end_buffer(self):
-        weechat_otr.command_cb(None, 'server_nick2_buffer', 'end')
+        self.call_command_cb(None, 'server_nick2_buffer', 'end')
 
         self.assertEqual(self.context.disconnects, 1)
 
     def test_end_args(self):
-        weechat_otr.command_cb(None, None, 'end nick2 server')
+        self.call_command_cb(None, None, 'end nick2 server')
 
         self.assertEqual(self.context.disconnects, 1)

--- a/weechat_otr_test/test_command_start.py
+++ b/weechat_otr_test/test_command_start.py
@@ -14,14 +14,14 @@ import weechat_otr
 class CommandStartTestCase(WeechatOtrTestCase):
 
     def test_start_buffer(self):
-        weechat_otr.command_cb(None, 'server_nick2_buffer', 'start')
+        self.call_command_cb(None, 'server_nick2_buffer', 'start')
 
         self.assertIn(
             (u'', '/quote -server server PRIVMSG nick2 :?OTR?'),
             sys.modules['weechat'].commands)
 
     def test_start_args(self):
-        weechat_otr.command_cb(None, None, 'start nick2 server')
+        self.call_command_cb(None, None, 'start nick2 server')
 
         self.assertIn(
             (u'', '/quote -server server PRIVMSG nick2 :?OTR?'),
@@ -30,14 +30,14 @@ class CommandStartTestCase(WeechatOtrTestCase):
     # /otr refresh is an alias for /otr start
 
     def test_refresh_buffer(self):
-        weechat_otr.command_cb(None, 'server_nick2_buffer', 'refresh')
+        self.call_command_cb(None, 'server_nick2_buffer', 'refresh')
 
         self.assertIn(
             (u'', '/quote -server server PRIVMSG nick2 :?OTR?'),
             sys.modules['weechat'].commands)
 
     def test_refresh_args(self):
-        weechat_otr.command_cb(None, None, 'refresh nick2 server')
+        self.call_command_cb(None, None, 'refresh nick2 server')
 
         self.assertIn(
             (u'', '/quote -server server PRIVMSG nick2 :?OTR?'),

--- a/weechat_otr_test/test_fingerprint.py
+++ b/weechat_otr_test/test_fingerprint.py
@@ -21,7 +21,7 @@ class FingerprintTestCase(WeechatOtrTestCase):
         account2 = weechat_otr.ACCOUNTS['nick2@server2']
         account2.getPrivkey()
 
-        weechat_otr.command_cb(None, None, 'fingerprint')
+        self.call_command_cb(None, None, 'fingerprint')
 
         self.assertPrinted('', (
             'eval(${{color:default}}:! ${{color:brown}}otr${{color:default}}'
@@ -49,7 +49,7 @@ class FingerprintTestCase(WeechatOtrTestCase):
         account1 = weechat_otr.ACCOUNTS['nick@server']
         account1.getPrivkey()
 
-        weechat_otr.command_cb(None, None, 'fingerprint match')
+        self.call_command_cb(None, None, 'fingerprint match')
 
         self.assertNoPrintedContains('', 'notamachxxx@server')
 
@@ -95,7 +95,7 @@ class FingerprintTestCase(WeechatOtrTestCase):
         account2 = weechat_otr.ACCOUNTS['nick2@server2']
         account2.getPrivkey()
 
-        weechat_otr.command_cb(None, None, 'fingerprint all')
+        self.call_command_cb(None, None, 'fingerprint all')
 
         self.assertPrinted('', (
             'eval(${color:default}:! ${color:brown}otr${color:default}'

--- a/weechat_otr_test/test_policy.py
+++ b/weechat_otr_test/test_policy.py
@@ -12,7 +12,7 @@ import weechat_otr
 class TestPolicy(WeechatOtrTestCase):
 
     def test_policy_default_server_nick_buffer(self):
-        weechat_otr.command_cb(None, None, 'policy default')
+        self.call_command_cb(None, None, 'policy default')
 
         self.assertPrinted('server_nick_buffer', (
             'eval(${color:default}:! ${color:brown}otr${color:default} !:)\t'
@@ -38,7 +38,7 @@ class TestPolicy(WeechatOtrTestCase):
             'Change default policies with: /otr policy default NAME on|off'))
 
     def test_policy_default_no_server_nick_buffer(self):
-        weechat_otr.command_cb(None, 'non_private_buffer', 'policy default')
+        self.call_command_cb(None, 'non_private_buffer', 'policy default')
 
         self.assertPrinted('', (
             'Current default OTR policies:\n'

--- a/weechat_otr_test/test_smp.py
+++ b/weechat_otr_test/test_smp.py
@@ -14,7 +14,7 @@ class SmpTestCase(WeechatOtrTestCase):
     def test_smp_ask_nick_server_question_secret(self):
         context = self.setup_context('nick@server', 'nick2@server')
 
-        weechat_otr.command_cb(
+        self.call_command_cb(
             None, None, 'smp ask nick2 server question secret')
 
         self.assertEqual(('secret', 'question'), context.smp_init)
@@ -22,7 +22,7 @@ class SmpTestCase(WeechatOtrTestCase):
     def test_smp_ask_nick_server_secret(self):
         context = self.setup_context('nick@server', 'nick2@server')
 
-        weechat_otr.command_cb(
+        self.call_command_cb(
             None, None, 'smp ask nick2 server secret')
 
         self.assertEqual(('secret', None), context.smp_init)
@@ -30,9 +30,8 @@ class SmpTestCase(WeechatOtrTestCase):
     def test_smp_ask_nick_server_secret_non_ascii(self):
         context = self.setup_context('nick@server', 'nick2@server')
 
-        weechat_otr.command_cb(
-            None, None,
-            weechat_otr.PYVER.to_str('smp ask nick2 server motörhead'))
+        self.call_command_cb(
+            None, None, 'smp ask nick2 server motörhead')
 
         self.assertEqual(
             (weechat_otr.PYVER.to_str('motörhead'), None), context.smp_init)
@@ -40,7 +39,7 @@ class SmpTestCase(WeechatOtrTestCase):
     def test_smp_ask_question_secret(self):
         context = self.setup_context('nick@server', 'nick2@server')
 
-        weechat_otr.command_cb(
+        self.call_command_cb(
             None, 'server_nick2_buffer', 'smp ask question secret')
 
         self.assertEqual(('secret', 'question'), context.smp_init)
@@ -48,14 +47,14 @@ class SmpTestCase(WeechatOtrTestCase):
     def test_smp_ask_secret(self):
         context = self.setup_context('nick@server', 'nick2@server')
 
-        weechat_otr.command_cb(None, 'server_nick2_buffer', 'smp ask secret')
+        self.call_command_cb(None, 'server_nick2_buffer', 'smp ask secret')
 
         self.assertEqual(('secret', None), context.smp_init)
 
     def test_smp_ask_nick_server_question_secret_multiple_words(self):
         context = self.setup_context('nick@server', 'nick2@server')
 
-        weechat_otr.command_cb(
+        self.call_command_cb(
             None, None, "smp ask nick2 server 'what is the secret?' "
             "'eastmost penninsula is the secret'")
 
@@ -66,7 +65,7 @@ class SmpTestCase(WeechatOtrTestCase):
     def test_smp_respond_secret(self):
         context = self.setup_context('nick@server', 'nick2@server')
 
-        weechat_otr.command_cb(
+        self.call_command_cb(
             None, 'server_nick2_buffer', 'smp respond secret')
 
         self.assertEqual(('secret', ), context.smp_got_secret)
@@ -74,7 +73,7 @@ class SmpTestCase(WeechatOtrTestCase):
     def test_smp_respond_nick_server_secret(self):
         context = self.setup_context('nick@server', 'nick2@server')
 
-        weechat_otr.command_cb(
+        self.call_command_cb(
             None, 'server_nick2_buffer', 'smp respond nick2 server secret')
 
         self.assertEqual(('secret', ), context.smp_got_secret)
@@ -82,9 +81,8 @@ class SmpTestCase(WeechatOtrTestCase):
     def test_smp_respond_secret_non_ascii(self):
         context = self.setup_context('nick@server', 'nick2@server')
 
-        weechat_otr.command_cb(
-            None, 'server_nick2_buffer',
-            weechat_otr.PYVER.to_str('smp respond deathtöngue'))
+        self.call_command_cb(
+            None, 'server_nick2_buffer', 'smp respond deathtöngue')
 
         self.assertEqual(
             (weechat_otr.PYVER.to_str('deathtöngue'), ),
@@ -94,6 +92,6 @@ class SmpTestCase(WeechatOtrTestCase):
         context = self.setup_context('nick@server', 'nick2@server')
         context.in_smp = True
 
-        weechat_otr.command_cb(None, 'server_nick2_buffer', 'smp abort')
+        self.call_command_cb(None, 'server_nick2_buffer', 'smp abort')
 
         self.assertEqual([('SMP aborted.',)], context.smp_finishes)

--- a/weechat_otr_test/test_weechat_otr.py
+++ b/weechat_otr_test/test_weechat_otr.py
@@ -103,7 +103,7 @@ class WeechatOtrGeneralTestCase(WeechatOtrTestCase):
                 weechat_otr.msg_irc_from_plain(msg_action)))
 
     def test_command_cb_start_send_tag_off(self):
-        weechat_otr.command_cb(None, None, 'start')
+        self.call_command_cb(None, None, 'start')
 
         self.assertPrinted('server_nick_buffer', (
             'eval(${color:default}:! ${color:brown}otr${color:default} !:)\t'
@@ -120,7 +120,7 @@ class WeechatOtrGeneralTestCase(WeechatOtrTestCase):
     def test_command_cb_start_send_tag_off_no_hints(self):
         sys.modules['weechat'].config_options[
             'otr.general.hints'] = 'off'
-        weechat_otr.command_cb(None, None, 'start')
+        self.call_command_cb(None, None, 'start')
 
         self.assertNotPrinted('server_nick_buffer', (
             'eval(${color:default}:! ${color:brown}otr${color:default} !:)\t'
@@ -130,7 +130,7 @@ class WeechatOtrGeneralTestCase(WeechatOtrTestCase):
 
     def test_command_cb_start_send_tag_off_with_hints(self):
         sys.modules['weechat'].config_options['otr.general.hints'] = 'on'
-        weechat_otr.command_cb(None, None, 'start')
+        self.call_command_cb(None, None, 'start')
 
         self.assertPrinted('server_nick_buffer', (
             'eval(${color:default}:! ${color:brown}otr${color:default} !:)\t'
@@ -141,7 +141,7 @@ class WeechatOtrGeneralTestCase(WeechatOtrTestCase):
     def test_command_cb_start_send_tag_on(self):
         sys.modules['weechat'].config_options[
             'otr.policy.server.nick.nick.send_tag'] = 'on'
-        weechat_otr.command_cb(None, None, 'start')
+        self.call_command_cb(None, None, 'start')
 
         self.assertPrinted('server_nick_buffer', (
             'eval(${color:default}:! ${color:brown}otr${color:default} !:)\t'
@@ -155,7 +155,7 @@ class WeechatOtrGeneralTestCase(WeechatOtrTestCase):
         self.assertEqual(result, 'this is not an irc command')
 
     def test_print_buffer_not_private(self):
-        weechat_otr.command_cb(None, None, 'start no_window_nick server')
+        self.call_command_cb(None, None, 'start no_window_nick server')
         self.assertPrinted('non_private_buffer', (
             'eval(${color:default}:! ${color:brown}otr${color:default} !:)\t'
             '(color lightblue)'

--- a/weechat_otr_test/weechat_otr_test_case.py
+++ b/weechat_otr_test/weechat_otr_test_case.py
@@ -16,6 +16,10 @@ sys.modules['weechat'] = weechat_otr_test.mock_weechat.MockWeechat(
 # pylint: disable=wrong-import-position
 import weechat_otr
 
+# Python 2.6 compatibility
+if not hasattr(unittest.TestCase, 'assertIs'):
+    import unittest2 as unittest
+
 class WeechatOtrTestCase(unittest.TestCase):
 
     def setUp(self):

--- a/weechat_otr_test/weechat_otr_test_case.py
+++ b/weechat_otr_test/weechat_otr_test_case.py
@@ -70,3 +70,13 @@ class WeechatOtrTestCase(unittest.TestCase):
         weechat_otr.ACCOUNTS[account_name] = account
 
         return context
+
+    def call_command_cb(self, data, buf, args):
+        """Call the plugin's command_cb, but make sure that all arguments
+        are converted to an utf-8 encoded byte string first to mimic
+        weechat's behaviour better."""
+        return weechat_otr.command_cb(
+                None if data is None else weechat_otr.PYVER.to_str(data),
+                None if buf is None else weechat_otr.PYVER.to_str(buf),
+                weechat_otr.PYVER.to_str(args)
+                )


### PR DESCRIPTION
As mentioned in https://github.com/mmb/weechat-otr/pull/86 the changes for Python 2.6 compatibility are unfortunately a little bit more complicated than I initially thought. The most intrusive thing is still having to use `{n}` instead of `{}` in format strings, but I think that's fine.
Note that this patches potr before running the tests on travis, see https://github.com/python-otr/pure-python-otr/pull/55.
