### PR TITLE
Sugguest installing potr with user schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This script requires Weechat 0.4.2 or later and the
 [Pure Python OTR](https://github.com/afflux/pure-python-otr)
 package to be installed:
 
-`pip install python-potr`
+`pip install --user python-potr`
 
 The latest release version of WeeChat OTR can be found in the
 [WeeChat scripts repository](https://www.weechat.org/scripts/source/otr.py.html/).


### PR DESCRIPTION
This avoids problems when sudo access is not available.

Not everyone knows how to use pip properly and hopefully this makes it less error-prone to install weechat-otr for a larger user base (though we might have to add a note about installing python-dev which needs roots access again).