### PR TITLE
weechat_otr.py: don't OTR with Anope services

### DIFF
--- a/weechat_otr.py
+++ b/weechat_otr.py
@@ -973,9 +973,13 @@ Note: You can safely omit specifying the peer and server when
 
     def is_serv(self):
         return self.peer_nick.lower() in [
+            'botserv',
             'chanserv',
+            'hostserv',
             'memoserv',
-            'nickserv'
+            'nickserv',
+            'operserv',
+            'statserv'
             ]
 
     def __repr__(self):


### PR DESCRIPTION
This adds all services supported by Anope into the services list. They
don't handle receiving the tag correctly.

Atheme must be added separately as it has more services and there is no
clear list of those anywhere other than example config files.

This list of Anope services is based on http://anope.org/about.php and
StatServ was said to be supported at IRC and it was said to be too new
one to appear on that page.

ref: #114