### PR TITLE
README.md: add more installation methods for potr

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,16 @@ Testing and security auditing are appreciated.
 
 This script requires Weechat 0.4.2 or later and the
 [Pure Python OTR](https://github.com/afflux/pure-python-otr)
-package to be installed (see below if this command fails):
+package to be installed with one of the following methods:
 
-    pip install --upgrade --user python-potr
+```bash
+# Arch
+yaourt -S python2-potr
+# Debian based systems
+sudo apt-get install python-potr
+# If this fails, read "Requirements for building Pure Python OTR" below.
+pip install --upgrade --user python-potr
+```
 
 The latest release version of WeeChat OTR can be found in the
 [WeeChat scripts repository](https://www.weechat.org/scripts/source/otr.py.html/).
@@ -36,7 +43,11 @@ in WeeChat.
 If python-potr fails to install, you are probably missing some packages.
 To install all the requirements on a Debian/Ubuntu system, run
 
-    sudo apt-get install python-pip build-essential python-dev
+    sudo apt-get install python-pip python-wheel build-essential python-dev
+
+Or on Arch run
+
+    sudo pacman --needed -S python2-pip python2-wheel python2-keyring base-devel
 
 ## Support
 


### PR DESCRIPTION
Package manager would possibly be preferred to pip and if pip is
installed, installing the wheel module will make it a lot faster.

I also added Arch for potr requirements, because unlike most of other
distributions it uses Python 3 by default (which is why PEP 394 was
made).

No code changes so,
[CI SKIP]
